### PR TITLE
feat: hide shopify colour swatch -  hide mpg-swatch option set button in CSS

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -3601,3 +3601,7 @@ details-disclosure > details {
 .product-description-link {
   color: #000;
 }
+
+.mpg-button.mpg-swatch__option-set {
+  display: none;
+}


### PR DESCRIPTION
Hides the mpg-swatch option set button by setting its display 
to none. This change improves the user interface by removing 
unnecessary elements that may confuse users.