### PR TITLE
feat(footer): add customizable background image to footer

### DIFF
--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -1,5 +1,6 @@
 .footer {
   border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  position: relative;
 }
 
 .footer:not(.color-scheme-1) {
@@ -505,4 +506,15 @@
       padding-left: 3rem;
     }
   }
+}
+
+.footer-background-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -29,6 +29,8 @@
 {%- endstyle -%}
 
 <footer class="footer color-{{ section.settings.color_scheme }} gradient section-{{ section.id }}-padding">
+  <div class="footer-background-image" style="background-image: url('{{ section.settings.background_image | image_url }}')"></div>
+
   {%- liquid
     assign has_social_icons = true
     if settings.social_facebook_link == blank and settings.social_instagram_link == blank and settings.social_youtube_link == blank and settings.social_tiktok_link == blank and settings.social_twitter_link == blank and settings.social_pinterest_link == blank and settings.social_snapchat_link == blank and settings.social_tumblr_link == blank and settings.social_vimeo_link == blank
@@ -634,6 +636,11 @@
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
       "default": "scheme-1"
+    },
+    {
+      "type": "image_picker",
+      "id": "background_image",
+      "label": "Footer Background Image"
     },
     {
       "type": "header",


### PR DESCRIPTION
Adds a new footer background image feature by introducing a 
`.footer-background-image` class in the CSS and updating the 
Liquid template to include an image picker setting. This allows 
users to set a custom background image for the footer, enhancing 
the visual appeal and customization options