### PR TITLE
feat(meta-tags): add Google site verification meta tag

### DIFF
--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -18,6 +18,7 @@
 <meta property="og:title" content="{{ og_title | escape }}">
 <meta property="og:type" content="{{ og_type }}">
 <meta property="og:description" content="{{ og_description | escape }}">
+<meta name="google-site-verification" content="hqfUdoAzBPcucHlJNWk8pEmNg7b9redrOVVSyB8wgP4" />
 
 {%- if page_image -%}
   <meta property="og:image" content="http:{{ page_image | image_url }}">


### PR DESCRIPTION
Adds a Google site verification meta tag to the meta-tags.liquid file.  
This change enables Google to verify ownership of the site, which is  
necessary for utilizing various Google services and tools.