### PR TITLE
feat(image-banner): add logo block to image banner section

### DIFF
--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -118,7 +118,15 @@
   <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
     <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
       {%- for block in section.blocks -%}
+     
+
+
+        
         {%- case block.type -%}
+
+        {%- when 'logo' -%}
+          {{ block.settings.header_logo | img_url: '300x100' | img_tag: 'header-image' }}
+
           {%- when 'heading' -%}
             <h2
               class="banner__heading inline-richtext {{ block.settings.heading_size }}"
@@ -126,6 +134,9 @@
             >
               {{ block.settings.heading }}
             </h2>
+
+         
+
           {%- when 'text' -%}
             <div class="banner__text rte {{ block.settings.text_style }}" {{ block.shopify_attributes }}>
               <p>{{ block.settings.text }}</p>
@@ -398,9 +409,11 @@
               "label": "t:sections.all.heading_size.options__5.label"
             }
           ],
+          
           "default": "h1",
           "label": "t:sections.all.heading_size.label"
         }
+        
       ]
     },
     {
@@ -478,12 +491,27 @@
           "label": "t:sections.image-banner.blocks.buttons.settings.button_style_secondary_2.label"
         }
       ]
+    }, 
+    {
+      "type": "logo",
+      "name": "Logo",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "header_logo",
+          "label": "Logo"
+        }
+      ]
     }
   ],
   "presets": [
     {
       "name": "t:sections.image-banner.presets.name",
       "blocks": [
+        {
+          "type": "logo"
+        },
         {
           "type": "heading"
         },


### PR DESCRIPTION
Adds a new 'logo' block to the image banner section, allowing users 
to upload a logo image. Updates the schema to include the logo block 
and its settings, enhancing the customization options for the banner. 
This change improves the visual appeal and branding capabilities of 
the section.